### PR TITLE
Fix Windows encoding errors for UTF-8 content

### DIFF
--- a/agent_session_viewer/main.py
+++ b/agent_session_viewer/main.py
@@ -351,7 +351,7 @@ async def index():
     """Serve the SPA."""
     index_path = STATIC_DIR / "index.html"
     if index_path.exists():
-        return index_path.read_text()
+        return index_path.read_text(encoding="utf-8")
     return "<h1>Claude Code Session Viewer</h1><p>Static files not found.</p>"
 
 
@@ -370,6 +370,12 @@ def find_available_port(start_port: int = 8080) -> int:
 
 def cli():
     """CLI entry point for agent-session-viewer."""
+    # Windows console defaults to legacy encoding (e.g., cp1252) which can't
+    # handle Unicode characters in progress bars. Reconfigure to UTF-8.
+    if sys.platform == 'win32' and hasattr(sys.stdout, 'reconfigure'):
+        sys.stdout.reconfigure(encoding='utf-8', errors='backslashreplace')
+        sys.stderr.reconfigure(encoding='utf-8', errors='backslashreplace')
+
     parser = argparse.ArgumentParser(
         description="Agent Session Viewer - View AI agent coding sessions"
     )


### PR DESCRIPTION
On Windows, running `uvx agent-session-viewer` fails with encoding errors:

```
UnicodeDecodeError: 'charmap' codec can't decode byte 0x8d in position 12999
```

and

```
UnicodeEncodeError: 'charmap' codec can't encode characters in position 1-30
```

## Root Cause

Python on Windows defaults to the system locale encoding (e.g., cp1252) for:
1. File operations - `Path.read_text()` without explicit encoding
2. Console I/O - stdout/stderr encoding

The `index.html` file is UTF-8 encoded (as declared in its `<meta charset="UTF-8">`), and the progress bar uses Unicode block characters (`█`, `░`) that cp1252 cannot handle.

## Fix

- Add explicit `encoding="utf-8"` to `read_text()` when serving index.html
- Reconfigure stdout/stderr to UTF-8 on Windows at CLI startup using `sys.stdout.reconfigure()`

The Windows-specific stdout fix preserves the Unicode progress bar experience while only affecting Windows systems where the encoding issue occurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)